### PR TITLE
fixes bug in CountCondition, adds DefenseStructureDesire

### DIFF
--- a/StarCraft2Bot/Builds/Base/Condition/UnitCountCondition.cs
+++ b/StarCraft2Bot/Builds/Base/Condition/UnitCountCondition.cs
@@ -5,7 +5,7 @@ namespace StarCraft2Bot.Builds.Base.Condition
 {
     public class UnitCountCondition : ICondition
     {
-        public UnitCountCondition(UnitTypes unit, ValueRange count, UnitCountService service) : this(unit, count, service, ConditionOperator.Greater)
+        public UnitCountCondition(UnitTypes unit, ValueRange count, UnitCountService service) : this(unit, count, service, ConditionOperator.GreaterOrEqual)
         {
 
         }

--- a/StarCraft2Bot/Builds/Base/Condition/UnitCountCondition.cs
+++ b/StarCraft2Bot/Builds/Base/Condition/UnitCountCondition.cs
@@ -38,9 +38,9 @@ namespace StarCraft2Bot.Builds.Base.Condition
                     return count <= Count;
                 case ConditionOperator.GreaterOrEqual:
                     return count >= Count;
-                case ConditionOperator.Equal:
-                    return count > Count;
                 case ConditionOperator.Greater:
+                    return count > Count;
+                case ConditionOperator.Equal:
                 default:
                     return count == Count;
             }

--- a/StarCraft2Bot/Builds/Base/Condition/WorkerCountCondition.cs
+++ b/StarCraft2Bot/Builds/Base/Condition/WorkerCountCondition.cs
@@ -5,7 +5,7 @@ namespace StarCraft2Bot.Builds.Base.Condition
 {
     public class WorkerCountCondition : ICondition
     {
-        public WorkerCountCondition(ValueRange count, UnitCountService service) : this(count, service, ConditionOperator.Greater)
+        public WorkerCountCondition(ValueRange count, UnitCountService service) : this(count, service, ConditionOperator.GreaterOrEqual)
         {
 
         }

--- a/StarCraft2Bot/Builds/Base/Condition/WorkerCountCondition.cs
+++ b/StarCraft2Bot/Builds/Base/Condition/WorkerCountCondition.cs
@@ -52,9 +52,9 @@ namespace StarCraft2Bot.Builds.Base.Condition
                     return count <= WorkerCount;
                 case ConditionOperator.GreaterOrEqual:
                     return count >= WorkerCount;
-                case ConditionOperator.Equal:
-                    return count > WorkerCount;
                 case ConditionOperator.Greater:
+                    return count > WorkerCount;
+                case ConditionOperator.Equal:
                 default:
                     return count == WorkerCount;
             }

--- a/StarCraft2Bot/Builds/Base/Desires/DefenseStructureDesire.cs
+++ b/StarCraft2Bot/Builds/Base/Desires/DefenseStructureDesire.cs
@@ -1,0 +1,30 @@
+﻿using Sharky;
+using System;
+
+namespace StarCraft2Bot.Builds.Base.Desires
+{
+    public class DefenseStructureDesire : IDesire
+    {
+        public UnitTypes StructureType { get; private set; }
+        public int Count { get; private set; }
+        public MacroData Data { get; private set; }
+        public bool Enforced { get; set; }
+
+        public DefenseStructureDesire(UnitTypes structureType, int count, MacroData data)
+        {
+            StructureType = structureType;
+            Count = count;
+            Data = data;
+        }
+
+        public void Enforce()
+        {
+            if (Enforced)
+                return;
+
+            Data.DesiredDefensiveBuildingsCounts[StructureType] = Count;            
+
+            Enforced = true;
+        }
+    }
+}


### PR DESCRIPTION
I've fixed a bug of two CountConditions. 
The switch-statement compared "equal" using the greater operator and checked for "greater than" using the equal operator.

In addition i've added a DefenseStructureDesire to build defensive buildings, which couldn't be build before.