### PR TITLE
fix mineral and gas calculations

### DIFF
--- a/StarCraft2Bot/Builds/Base/Desires/AddonStructureDesire.cs
+++ b/StarCraft2Bot/Builds/Base/Desires/AddonStructureDesire.cs
@@ -44,7 +44,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * typeData?.Minerals ?? 0;
+            return remainingCount * typeData?.Minerals ?? 0;
         }
 
         public int GetVespeneCost()
@@ -55,7 +55,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * typeData?.Gas ?? 0;
+            return remainingCount * typeData?.Gas ?? 0;
         }
 
         public AddonStructureDesire(UnitTypes addonType, ValueRange count, MacroData data, UnitCountService unitCountService)

--- a/StarCraft2Bot/Builds/Base/Desires/DefenseStructureDesire.cs
+++ b/StarCraft2Bot/Builds/Base/Desires/DefenseStructureDesire.cs
@@ -43,7 +43,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * buildingTypeData?.Minerals ?? 0;
+            return remainingCount * buildingTypeData?.Minerals ?? 0;
         }
 
         public int GetVespeneCost()
@@ -54,7 +54,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * buildingTypeData?.Gas ?? 0;
+            return remainingCount * buildingTypeData?.Gas ?? 0;
         }
 
         public DefenseStructureDesire(UnitTypes structureType, int count, MacroData data, UnitCountService unitCountService)

--- a/StarCraft2Bot/Builds/Base/Desires/GasBuildingCountDesire.cs
+++ b/StarCraft2Bot/Builds/Base/Desires/GasBuildingCountDesire.cs
@@ -77,7 +77,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * buildingTypeData?.Minerals ?? 0;
+            return remainingCount * buildingTypeData?.Minerals ?? 0;
         }
 
         public int GetVespeneCost()
@@ -88,7 +88,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * buildingTypeData?.Gas ?? 0;
+            return remainingCount * buildingTypeData?.Gas ?? 0;
         }
 
         public void Enforce()

--- a/StarCraft2Bot/Builds/Base/Desires/MorphDesire.cs
+++ b/StarCraft2Bot/Builds/Base/Desires/MorphDesire.cs
@@ -44,7 +44,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * typeData?.Minerals ?? 0;
+            return remainingCount * typeData?.Minerals ?? 0;
         }
 
         public int GetVespeneCost()
@@ -55,7 +55,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * typeData?.Gas ?? 0;
+            return remainingCount * typeData?.Gas ?? 0;
         }
 
         public MorphDesire(UnitTypes targetType, ValueRange count, MacroData data, UnitCountService unitCountService)

--- a/StarCraft2Bot/Builds/Base/Desires/ProductionStructureDesire.cs
+++ b/StarCraft2Bot/Builds/Base/Desires/ProductionStructureDesire.cs
@@ -45,7 +45,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * buildingTypeData?.Minerals ?? 0;
+            return remainingCount * buildingTypeData?.Minerals ?? 0;
         }
 
         public int GetVespeneCost()
@@ -56,7 +56,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * buildingTypeData?.Gas ?? 0;
+            return remainingCount * buildingTypeData?.Gas ?? 0;
         }
 
         public ProductionStructureDesire(UnitTypes structureType, ValueRange count, MacroData data, UnitCountService unitCountService)

--- a/StarCraft2Bot/Builds/Base/Desires/ProxyProductionStructureDesire.cs
+++ b/StarCraft2Bot/Builds/Base/Desires/ProxyProductionStructureDesire.cs
@@ -47,7 +47,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * buildingTypeData?.Minerals ?? 0;
+            return remainingCount * buildingTypeData?.Minerals ?? 0;
         }
 
         public int GetVespeneCost()
@@ -58,7 +58,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * buildingTypeData?.Gas ?? 0;
+            return remainingCount * buildingTypeData?.Gas ?? 0;
         }
 
         public ProxyProductionStructureDesire(UnitTypes structureType, ValueRange count, MacroData data, string proxyName, UnitCountService unitCountService)

--- a/StarCraft2Bot/Builds/Base/Desires/SupplyDepotDesire.cs
+++ b/StarCraft2Bot/Builds/Base/Desires/SupplyDepotDesire.cs
@@ -54,7 +54,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * buildingTypeData?.Minerals ?? 0;
+            return remainingCount * buildingTypeData?.Minerals ?? 0;
         }
 
         public int GetVespeneCost()
@@ -65,7 +65,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * buildingTypeData?.Gas ?? 0;
+            return remainingCount * buildingTypeData?.Gas ?? 0;
         }
 
         public void Enforce()

--- a/StarCraft2Bot/Builds/Base/Desires/TechStructureDesire.cs
+++ b/StarCraft2Bot/Builds/Base/Desires/TechStructureDesire.cs
@@ -43,7 +43,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * buildingTypeData?.Minerals ?? 0;
+            return remainingCount * buildingTypeData?.Minerals ?? 0;
         }
 
         public int GetVespeneCost()
@@ -54,7 +54,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * buildingTypeData?.Gas ?? 0;
+            return remainingCount * buildingTypeData?.Gas ?? 0;
         }
 
         public TechStructureDesire(UnitTypes structureType, int count, MacroData data, UnitCountService unitCountService)

--- a/StarCraft2Bot/Builds/Base/Desires/UnitDesire.cs
+++ b/StarCraft2Bot/Builds/Base/Desires/UnitDesire.cs
@@ -83,7 +83,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * typeData?.Minerals ?? 0;
+            return remainingCount * typeData?.Minerals ?? 0;
         }
 
         public int GetVespeneCost()
@@ -94,7 +94,7 @@ namespace StarCraft2Bot.Builds.Base.Desires
             if (remainingCount <= 0)
                 return 0;
 
-            return existingCount * typeData?.Gas ?? 0;
+            return remainingCount * typeData?.Gas ?? 0;
         }
     }
 }


### PR DESCRIPTION
fixes mineral and gas calculation bug for desires.
Previously mineral and gas costs were calculated using the existingCount for a desire, should use remainingCount instead.